### PR TITLE
Add display identifier for user input and response for preparing multiline input and answers

### DIFF
--- a/duck_chat/__init__.py
+++ b/duck_chat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 from .api import DuckChat  # noqa
 from .config import ModelType  # noqa

--- a/duck_chat/__main__.py
+++ b/duck_chat/__main__.py
@@ -7,13 +7,16 @@ from .config import ModelType
 
 async def main():
     async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
+        print('Type \033[1;4mstop\033[0m to quit')
         while True:
             try:
+                print("\033[1;4m>>> User input:\033[0m", end="\n")
                 question = input()
             except EOFError:
                 sys.exit(0)
             if question == "stop":
                 break
+            print("\033[1;4m>>> Response:\033[0m", end="\n")
             print(await chat.ask_question(question))
 
 


### PR DESCRIPTION
Hello @mrgick 

You can tell me if you prefer maybe that I do a bit more in this PR or not. I think it can stand on his own because it visually helps to know what our input and the response.

It will help even more when I add the multiline input because it can be very difficult to read when we copy and paste a big block of text. As always, you can refactor a bit if needed and tell me if you prefer to merge it alone or if I add some more stuff inside the PR, but I would prefer that it would be for another one, to be honest.

Have a good day, and I add below an example from my shell.

![Capture d’écran_2024-07-19_20-14-26](https://github.com/user-attachments/assets/67ddc245-bcc7-417b-a0a5-96823ca75421)
