### PR TITLE
Add multiline support and use command for changing behavior

### DIFF
--- a/duck_chat/__init__.py
+++ b/duck_chat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 from .api import DuckChat  # noqa
 from .config import ModelType  # noqa

--- a/duck_chat/__main__.py
+++ b/duck_chat/__main__.py
@@ -1,11 +1,11 @@
 import asyncio
 import sys
 
-from .cli import run
+from .cli import CLI
 
 
 async def main():
-    await run()
+    await CLI().run()
 
 
 if __name__ == "__main__":

--- a/duck_chat/__main__.py
+++ b/duck_chat/__main__.py
@@ -1,23 +1,62 @@
 import asyncio
+import re
 import sys
 
 from .api import DuckChat
 from .config import ModelType
 
-
 async def main():
+    # Parsing input and define action variable to control the loop flow
+    def parsing_input_and_action(user_input):
+        if re.match("^/help", question):
+            print("\033[1;4m>>> Command response:\033[0m", end="\n")
+            print("\033[1;1m- /help         \033[0mDisplay the help message")
+            print("\033[1;1m- /singleline   \033[0mEnable singleline mode, validate is done by <enter>")
+            print("\033[1;1m- /multiline    \033[0mEnable multiline mode, validate is done by \\")
+            print("\033[1;1m- /quit         \033[0mQuit")
+            return "continue"
+        if re.match("^/singleline", question):
+            return "singleline"
+        if re.match("^/multiline", question):
+            return  "multiline"
+        if re.match("^/quit", question):
+            return "break"
+
+    # How get user input
+    # It can be updated if multiline is enabled
+    def get_user_input():
+        return input().strip()
+
     async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
-        print('Type \033[1;4mstop\033[0m to quit')
+        print('Type \033[1;4m/help\033[0m to display the help')
         while True:
             try:
                 print("\033[1;4m>>> User input:\033[0m", end="\n")
-                question = input()
+
+                question = get_user_input()
+                action = parsing_input_and_action(question)
             except EOFError:
                 sys.exit(0)
-            if question == "stop":
+
+            if action == "break":
                 break
-            print("\033[1;4m>>> Response:\033[0m", end="\n")
-            print(await chat.ask_question(question))
+            elif action == "continue":
+                continue
+            elif action == "singleline":
+                def get_user_input():
+                    return input()
+            elif action == "multiline":
+                def get_user_input():
+                    lines = []
+                    while True:
+                        line = input().strip()
+                        lines.append(line)
+                        if line.endswith("\\"):
+                            break
+                    return "\n".join(lines)
+            else:
+                print("\033[1;4m>>> Response:\033[0m", end="\n")
+                print(await chat.ask_question(question))
 
 
 if __name__ == "__main__":

--- a/duck_chat/__main__.py
+++ b/duck_chat/__main__.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 
 from .cli import CLI
 
@@ -9,7 +8,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    try:
-        asyncio.run(main())
-    except KeyboardInterrupt:
-        sys.exit(0)
+    asyncio.run(main())

--- a/duck_chat/__main__.py
+++ b/duck_chat/__main__.py
@@ -1,62 +1,11 @@
 import asyncio
-import re
 import sys
 
-from .api import DuckChat
-from .config import ModelType
+from .cli import run
+
 
 async def main():
-    # Parsing input and define action variable to control the loop flow
-    def parsing_input_and_action(user_input):
-        if re.match("^/help", question):
-            print("\033[1;4m>>> Command response:\033[0m", end="\n")
-            print("\033[1;1m- /help         \033[0mDisplay the help message")
-            print("\033[1;1m- /singleline   \033[0mEnable singleline mode, validate is done by <enter>")
-            print("\033[1;1m- /multiline    \033[0mEnable multiline mode, validate is done by \\")
-            print("\033[1;1m- /quit         \033[0mQuit")
-            return "continue"
-        if re.match("^/singleline", question):
-            return "singleline"
-        if re.match("^/multiline", question):
-            return  "multiline"
-        if re.match("^/quit", question):
-            return "break"
-
-    # How get user input
-    # It can be updated if multiline is enabled
-    def get_user_input():
-        return input().strip()
-
-    async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
-        print('Type \033[1;4m/help\033[0m to display the help')
-        while True:
-            try:
-                print("\033[1;4m>>> User input:\033[0m", end="\n")
-
-                question = get_user_input()
-                action = parsing_input_and_action(question)
-            except EOFError:
-                sys.exit(0)
-
-            if action == "break":
-                break
-            elif action == "continue":
-                continue
-            elif action == "singleline":
-                def get_user_input():
-                    return input()
-            elif action == "multiline":
-                def get_user_input():
-                    lines = []
-                    while True:
-                        line = input().strip()
-                        lines.append(line)
-                        if line.endswith("\\"):
-                            break
-                    return "\n".join(lines)
-            else:
-                print("\033[1;4m>>> Response:\033[0m", end="\n")
-                print(await chat.ask_question(question))
+    await run()
 
 
 if __name__ == "__main__":

--- a/duck_chat/cli.py
+++ b/duck_chat/cli.py
@@ -10,46 +10,51 @@ HELP_MSG = """
 \033[1;1m- /quit         \033[0mQuit"""[1:] # noqa
 
 
-async def run():
-    async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
-        INPUT_MODE = "singleline"
-        print("Type \033[1;4m/help\033[0m to display the help")
-        while True:
-            print("\033[1;4m>>> User input:\033[0m", end="\n")
+class CLI:
+    INPUT_MODE = "singleline"
 
-            # get user question
-            if INPUT_MODE == "singleline":
-                user_input = input().strip()
-            else:
-                user_input = sys.stdin.read().strip()
+    async def run(self) -> None:
+        """Base loop program"""
+        async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
+            print("Type \033[1;4m/help\033[0m to display the help")
 
-            # if user input is command
-            if user_input.startswith("/"):
-                print("\033[1;4m>>> Command response:\033[0m")
-                match user_input[1:]:
-                    case "singleline":
-                        INPUT_MODE = "singleline"
-                        print(
-                            "Switched to singleline mode, validate is done by <enter>"
-                        )
-                    case "multiline":
-                        INPUT_MODE = "multiline"
-                        print(
-                            "Switched to multiline mode, validate is done by EOF <Ctrl+D>"
-                        )
-                    case "quit":
-                        print("Quit")
-                        sys.exit(0)
-                    case "help":
-                        print(HELP_MSG)
-                    case _:
-                        print("Command doesn't find")
-                        print("Type \033[1;4m/help\033[0m to display the help")
-                continue
+            while True:
+                print("\033[1;4m>>> User input:\033[0m", end="\n")
 
-            # empty user input
-            if not user_input:
-                continue
+                # get user question
+                if self.INPUT_MODE == "singleline":
+                    user_input = input().strip()
+                else:
+                    user_input = sys.stdin.read().strip()
 
-            print("\033[1;4m>>> Response:\033[0m", end="\n")
-            print(await chat.ask_question(user_input))
+                # if user input is command
+                if user_input.startswith("/"):
+                    self.command_parsing(user_input[1:])
+                    continue
+
+                # empty user input
+                if not user_input:
+                    print("\033[1;4m>>> Bad input\033[0m")
+                    continue
+
+                print("\033[1;4m>>> Response:\033[0m", end="\n")
+                print(await chat.ask_question(user_input))
+
+    def command_parsing(self, command: str) -> None:
+        """Recognize command"""
+        print("\033[1;4m>>> Command response:\033[0m")
+        match command:
+            case "singleline":
+                self.INPUT_MODE = "singleline"
+                print("Switched to singleline mode, validate is done by <enter>")
+            case "multiline":
+                self.INPUT_MODE = "multiline"
+                print("Switched to multiline mode, validate is done by EOF <Ctrl+D>")
+            case "quit":
+                print("Quit")
+                sys.exit(0)
+            case "help":
+                print(HELP_MSG)
+            case _:
+                print("Command doesn't find")
+                print("Type \033[1;4m/help\033[0m to display the help")

--- a/duck_chat/cli.py
+++ b/duck_chat/cli.py
@@ -1,0 +1,55 @@
+import sys
+
+from .api import DuckChat
+from .config import ModelType
+
+HELP_MSG = """
+\033[1;1m- /help         \033[0mDisplay the help message
+\033[1;1m- /singleline   \033[0mEnable singleline mode, validate is done by <enter>
+\033[1;1m- /multiline    \033[0mEnable multiline mode, validate is done by EOF <Ctrl+D>
+\033[1;1m- /quit         \033[0mQuit"""[1:] # noqa
+
+
+async def run():
+    async with DuckChat(model=ModelType.read_model_from_conf()) as chat:
+        INPUT_MODE = "singleline"
+        print("Type \033[1;4m/help\033[0m to display the help")
+        while True:
+            print("\033[1;4m>>> User input:\033[0m", end="\n")
+
+            # get user question
+            if INPUT_MODE == "singleline":
+                user_input = input().strip()
+            else:
+                user_input = sys.stdin.read().strip()
+
+            # if user input is command
+            if user_input.startswith("/"):
+                print("\033[1;4m>>> Command response:\033[0m")
+                match user_input[1:]:
+                    case "singleline":
+                        INPUT_MODE = "singleline"
+                        print(
+                            "Switched to singleline mode, validate is done by <enter>"
+                        )
+                    case "multiline":
+                        INPUT_MODE = "multiline"
+                        print(
+                            "Switched to multiline mode, validate is done by EOF <Ctrl+D>"
+                        )
+                    case "quit":
+                        print("Quit")
+                        sys.exit(0)
+                    case "help":
+                        print(HELP_MSG)
+                    case _:
+                        print("Command doesn't find")
+                        print("Type \033[1;4m/help\033[0m to display the help")
+                continue
+
+            # empty user input
+            if not user_input:
+                continue
+
+            print("\033[1;4m>>> Response:\033[0m", end="\n")
+            print(await chat.ask_question(user_input))

--- a/duck_chat/cli.py
+++ b/duck_chat/cli.py
@@ -23,7 +23,7 @@ class CLI:
 
                 # get user question
                 if self.INPUT_MODE == "singleline":
-                    user_input = input().strip()
+                    user_input = sys.stdin.readline().strip()
                 else:
                     user_input = sys.stdin.read().strip()
 
@@ -34,7 +34,7 @@ class CLI:
 
                 # empty user input
                 if not user_input:
-                    print("\033[1;4m>>> Bad input\033[0m")
+                    print("Bad input")
                     continue
 
                 print("\033[1;4m>>> Response:\033[0m", end="\n")


### PR DESCRIPTION
Hello @mrgick 

I find this one a bit dirty to be honest but it is working at first view, but if you see a better way to implement it don't hesitate. If you think it's a bit outside the scope don't hesitate to tell me too.

I think there would be some explain after `/singleline` and `/multiline` like how they work and stuff like that.

`/help` command

![Capture d’écran_2024-07-20_17-53-17](https://github.com/user-attachments/assets/57ce9948-8099-40f8-8d7f-38f9876d9b80)

using `/multiline`

![Capture d’écran_2024-07-20_17-53-48](https://github.com/user-attachments/assets/a0a6c8a6-9b20-432f-8e15-cd81ebdca3ad)

switching back to `/singleline` and checking what was sent before and then `/quit`

![Capture d’écran_2024-07-20_17-54-19](https://github.com/user-attachments/assets/56683705-2299-4c1a-a2ef-db3b30c04b4e)
